### PR TITLE
fix: shorten default resource prefix to avoid storage name length errors

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -8,7 +8,7 @@ This folder contains the infrastructure-as-code to deploy all Azure resources ne
 
 Click the button above to deploy directly from the Azure Portal. You'll be prompted for:
 - **User Object ID** — run `az ad signed-in-user show --query id -o tsv` to get yours
-- **Resource Prefix** — a short name prefix for all resources (default: `iqseries`)
+- **Resource Prefix** — a short name prefix for all resources (default: `iqs`)
 - **Location** — Azure region (must support [agentic retrieval](https://learn.microsoft.com/azure/search/search-region-support))
 
 > **⚠️ Troubleshooting: Deployment script failed?**

--- a/infra/azuredeploy.json
+++ b/infra/azuredeploy.json
@@ -17,7 +17,7 @@
     },
     "resourcePrefix": {
       "type": "string",
-      "defaultValue": "iqseries",
+      "defaultValue": "iqs",
       "metadata": {
         "description": "Resource name prefix"
       }

--- a/infra/deploy.ps1
+++ b/infra/deploy.ps1
@@ -9,7 +9,7 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$Location,
 
-    [string]$ResourcePrefix = "iqseries",
+    [string]$ResourcePrefix = "iqs",
 
     [string]$SearchSku = "standard"
 )

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -7,7 +7,7 @@ set -e
 
 RESOURCE_GROUP=""
 LOCATION=""
-RESOURCE_PREFIX="iqseries"
+RESOURCE_PREFIX="iqs"
 SEARCH_SKU="standard"
 
 # Parse arguments
@@ -25,7 +25,7 @@ while getopts "g:l:p:s:h" opt; do
       echo "  -l  Azure location (e.g., eastus2)"
       echo ""
       echo "Optional:"
-      echo "  -p  Resource prefix (default: iqseries)"
+      echo "  -p  Resource prefix (default: iqs)"
       echo "  -s  Search service SKU (default: standard)"
       echo "  -h  Show this help message"
       exit 0

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -10,7 +10,7 @@
 param userObjectId string
 
 @description('Resource name prefix')
-param resourcePrefix string = 'iqseries'
+param resourcePrefix string = 'iqs'
 
 @description('Azure region — must support agentic retrieval (see https://learn.microsoft.com/azure/search/search-region-support)')
 param location string = 'eastus2'

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "resourcePrefix": {
-      "value": "iqseries"
+      "value": "iqs"
     },
     "location": {
       "value": "eastus2"


### PR DESCRIPTION
The default resourcePrefix 'iqseries' caused deployment failures because the generated storage account name exceeded Azure's 24-character limit.

Changed default prefix from 'iqseries' to 'iqs' across all infra files.

Fixes #15