### PR TITLE
docs: correct Foundry model deployment example to gpt-4o-mini

### DIFF
--- a/1-Foundry-IQ-Unlocking-Knowledge-for-Agents/cookbook/foundry-iq-cookbook.ipynb
+++ b/1-Foundry-IQ-Unlocking-Knowledge-for-Agents/cookbook/foundry-iq-cookbook.ipynb
@@ -448,7 +448,7 @@
     "\n",
     "```\n",
     "FOUNDRY_PROJECT_ENDPOINT=https://<your-foundry-resource>.services.ai.azure.com/api/projects/<your-project>\n",
-    "FOUNDRY_MODEL_DEPLOYMENT_NAME=gpt-4o\n",
+    "FOUNDRY_MODEL_DEPLOYMENT_NAME=gpt-4o-mini\n",
     "FOUNDRY_PROJECT_RESOURCE_ID=/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.MachineLearningServices/workspaces/<workspace>/projects/<project>\n",
     "```"
    ]


### PR DESCRIPTION
## Summary
- correct the Foundry model deployment example in the Episode 1 cookbook
- use gpt-4o-mini consistently with the rest of the notebook and environment variable examples

## Testing
- not run (documentation-only change)